### PR TITLE
✨ feat: update time on worklog upon each tick

### DIFF
--- a/src/atoms/listener.ts
+++ b/src/atoms/listener.ts
@@ -4,7 +4,7 @@ import { StorageKey, setInStorage } from '../services/storage.service';
 import { jiraAuthAtom } from './auth';
 import { settingsAtom } from './setting';
 import { store } from './store';
-import { activeWorklogAtom, activeWorklogTrackingDurationAtom, worklogsLocalAtom } from './worklog';
+import { activeWorklogAtom, worklogsLocalAtom } from './worklog';
 
 /**
  * Persist changes to AsyncStorage
@@ -26,17 +26,6 @@ store.sub(worklogsLocalAtom, () => {
 /**
  * Communicate with status bar widget
  */
-store.sub(activeWorklogTrackingDurationAtom, () => {
-  const activeWorklog = store.get(activeWorklogAtom);
-  if (activeWorklog) {
-    sendNativeEvent({
-      name: NativeEvent.STATUS_BAR_TIME_CHANGE,
-      data: activeWorklog.timeSpentSeconds.toString(),
-    });
-  } else {
-    sendNativeEvent({ name: NativeEvent.STATUS_BAR_TIME_CHANGE, data: 'null' });
-  }
-});
 store.sub(activeWorklogAtom, () => {
   const activeWorklog = store.get(activeWorklogAtom);
   const time = activeWorklog?.timeSpentSeconds ?? 0;

--- a/src/components/DayButton.tsx
+++ b/src/components/DayButton.tsx
@@ -3,7 +3,6 @@ import React, { FC, useState } from 'react';
 import { Image, Platform, Pressable, PressableProps, StyleSheet, Text, View } from 'react-native';
 import {
   activeWorklogAtom,
-  activeWorklogTrackingDurationAtom,
   hideNonWorkingDaysAtom,
   selectedDateAtom,
   sidebarLayoutAtom,
@@ -36,8 +35,6 @@ export const DayButton: FC<DayButtonProps> = ({ onPress, dayCode, dateString }) 
   const worklogs = useAtomValue(worklogsAtom);
   const selectedDate = useAtomValue(selectedDateAtom);
   const activeWorklog = useAtomValue(activeWorklogAtom);
-  const activeWorklogTrackingDuration = useAtomValue(activeWorklogTrackingDurationAtom);
-  const activeWorklogIsThisDay = activeWorklog?.started === dateString;
   const { t } = useTranslation();
 
   if (hideNonWorkingDays && !isWorkingDay) {
@@ -55,17 +52,14 @@ export const DayButton: FC<DayButtonProps> = ({ onPress, dayCode, dateString }) 
   let duration = worklogs
     .filter(worklog => worklog.started === dateString)
     .reduce((acc, worklog) => acc + worklog.timeSpentSeconds, 0);
-  if (activeWorklogIsThisDay) {
-    duration += activeWorklogTrackingDuration;
-  }
   const isSelected = selectedDate === dateString;
 
   const worklogsForThisDay = worklogs.filter(worklog => worklog.started === dateString);
   const isChecked =
     worklogsForThisDay.length > 0 && worklogsForThisDay.every(worklog => worklog.state === WorklogState.SYNCED);
-  const hasChanges =
-    activeWorklogIsThisDay ||
-    worklogsForThisDay.some(worklog => worklog.started === dateString && worklog.state !== WorklogState.SYNCED);
+  const hasChanges = worklogsForThisDay.some(
+    worklog => worklog.started === dateString && worklog.state !== WorklogState.SYNCED
+  );
 
   return (
     <Pressable

--- a/src/components/TrackingListEntry.tsx
+++ b/src/components/TrackingListEntry.tsx
@@ -2,13 +2,7 @@ import { useAtomValue, useSetAtom } from 'jotai';
 import transparentize from 'polished/lib/color/transparentize';
 import React, { FC } from 'react';
 import { Pressable, PressableProps, StyleSheet, Text, View } from 'react-native';
-import {
-  activeWorklogAtom,
-  activeWorklogTrackingDurationAtom,
-  currentOverlayAtom,
-  currentWorklogToEditAtom,
-  setWorklogAsActiveAtom,
-} from '../atoms';
+import { activeWorklogAtom, currentOverlayAtom, currentWorklogToEditAtom, setWorklogAsActiveAtom } from '../atoms';
 import { Overlay } from '../const';
 import { useThemedStyles } from '../services/theme.service';
 import { Theme } from '../styles/theme/theme-types';
@@ -28,7 +22,6 @@ export const TrackingListEntry: FC<TrackingListEntryProps> = ({ worklog, isSelec
   const setCurrentWorklogToEdit = useSetAtom(currentWorklogToEditAtom);
   const activeWorklog = useAtomValue(activeWorklogAtom);
   const setWorklogAsActive = useSetAtom(setWorklogAsActiveAtom);
-  const activeWorklogTrackingDuration = useAtomValue(activeWorklogTrackingDurationAtom);
   const setCurrentOverlay = useSetAtom(currentOverlayAtom);
   const { onPress } = useDoublePress(() => {
     setCurrentWorklogToEdit(worklog);
@@ -37,11 +30,6 @@ export const TrackingListEntry: FC<TrackingListEntryProps> = ({ worklog, isSelec
   const styles = useThemedStyles(createStyles);
 
   const isActiveWorklog = activeWorklog?.id === worklog.id;
-
-  let duration = worklog.timeSpentSeconds;
-  if (isActiveWorklog) {
-    duration = worklog.timeSpentSeconds + activeWorklogTrackingDuration;
-  }
 
   return (
     <Pressable
@@ -56,8 +44,8 @@ export const TrackingListEntry: FC<TrackingListEntryProps> = ({ worklog, isSelec
                   worklog.state === WorklogState.SYNCED
                     ? 'lime'
                     : worklog.state === WorklogState.EDITED
-                    ? 'yellow'
-                    : 'aqua',
+                      ? 'yellow'
+                      : 'aqua',
               }}>
               [{worklog.state.substring(0, 1).toUpperCase()}]
             </Text>
@@ -70,7 +58,7 @@ export const TrackingListEntry: FC<TrackingListEntryProps> = ({ worklog, isSelec
         {worklog.comment && <Text style={styles.description}>{worklog.comment}</Text>}
       </View>
       <PlayPauseButton
-        duration={duration}
+        duration={worklog.timeSpentSeconds}
         isRunning={isActiveWorklog}
         onPress={() => {
           if (isActiveWorklog) {


### PR DESCRIPTION
This gets rid of the `activeWorklogTrackingDurationAtom` and instead writes the duration to the active worklog directly.
This allows us to use the `timeSpentSeconds` property of the active worklog directly in the UI without calculating anything.

@AdrianFahrbach does this work for you in terms of the status bar widget? I removed a listener there as the subscription listening for changes on `activeWorklogAtom` should be sufficient.